### PR TITLE
Added the test function and made the plugin more modular

### DIFF
--- a/lua/cook/commands.lua
+++ b/lua/cook/commands.lua
@@ -1,0 +1,27 @@
+local M = {}
+
+function M.check(opts)
+	local sub = opts.fargs[1]
+	if sub == "test" then
+		require("cook.test").test()
+	elseif sub == nil or sub == "" or sub == "run" then
+		require("cook.run").run()
+	else
+		vim.notify("Unknown subcommand: " .. tostring(sub), vim.log.levels.ERROR)
+	end
+end
+
+function M.register()
+	vim.api.nvim_create_user_command("Cook", function(opts)
+		M.check(opts)
+	end, {
+		nargs = "?",
+		complete = function(arglead)
+			local subs = { "run", "test" }
+			return vim.tbl_filter(function(x)
+				return x:match("^" .. arglead)
+			end, subs)
+		end,
+	})
+end
+return M

--- a/lua/cook/config.lua
+++ b/lua/cook/config.lua
@@ -8,8 +8,8 @@ local defaults = {
 	},
 	runners = {
 		py = "'python3 %s'",
-		c = "'gcc %s -o %s && .%s'",
-		cpp = "'g++ %s -o %s && .%s'",
+		c = "'gcc %s -o %s && %s'",
+		cpp = "'g++ %s -o %s && %s'",
 		rs = "'cargo run'",
 		js = "'bun %s'",
 		ts = "'bun %s'",

--- a/lua/cook/filetype.lua
+++ b/lua/cook/filetype.lua
@@ -3,6 +3,7 @@ local config = require("cook.config")
 local M = {}
 
 function M.resolve(filepath)
+	filepath = vim.fn.fnamemodify(filepath, ":p")
 	if type(filepath) ~= "string" then
 		vim.notify("Cook error: invalid filepath", vim.log.levels.ERROR)
 		return nil
@@ -29,7 +30,7 @@ function M.resolve(filepath)
 		local folder = vim.fn.fnamemodify(filepath, ":h")
 		local name = vim.fn.fnamemodify(filepath, ":t:r")
 		local exe = folder .. "/" .. name
-		return string.format(runner, filepath, exe, "/" .. name)
+		return string.format(runner, filepath, exe, exe)
 	end
 
 	return string.format(runner, filepath)

--- a/lua/cook/init.lua
+++ b/lua/cook/init.lua
@@ -1,28 +1,11 @@
 local config = require("cook.config")
-local executor = require("cook.executor")
-local filetype = require("cook.filetype")
+local commands = require("cook.commands")
 
 local M = {}
 
 function M.setup(user_config)
 	config.setup(user_config or {})
+	commands.register()
 end
-
-function M.cook()
-	local raw = vim.api.nvim_buf_get_name(0)
-	if not raw or raw == "" or raw:match("^%[.+%]$") then
-		vim.notify("Cannot cook unsaved or unnamed buffer.", vim.log.levels.ERROR)
-		return
-	end
-
-	local cmd = filetype.resolve(raw)
-	if not cmd then
-		return
-	end
-
-	executor.run(cmd)
-end
-
-vim.api.nvim_create_user_command("Cook", M.cook, {})
 
 return M

--- a/lua/cook/run.lua
+++ b/lua/cook/run.lua
@@ -1,0 +1,19 @@
+local resolve = require("cook.filetype").resolve
+local executor = require("cook.executor")
+
+local M = {}
+
+function M.run()
+	local raw = vim.api.nvim_buf_get_name(0)
+	if not raw or raw == "" or raw:match("^%[.+%]$") then
+		vim.notify("Cannot cook unsaved or unnamed buffer.", vim.log.levels.ERROR)
+		return
+	end
+
+	local cmd = resolve(raw)
+	if cmd then
+		executor.run(cmd)
+	end
+end
+
+return M

--- a/lua/cook/test.lua
+++ b/lua/cook/test.lua
@@ -1,0 +1,31 @@
+local executor = require("cook.executor")
+local resolve = require("cook.filetype").resolve
+
+local M = {}
+
+function M.test()
+	local raw = vim.api.nvim_buf_get_name(0)
+	if not raw or raw == "" or raw:match("^%[.+%]$") then
+		vim.notify("Cannot cook unsaved or unnamed buffer.", vim.log.levels.ERROR)
+		return
+	end
+
+	local cmd = resolve(raw)
+	if not cmd then
+		return
+	end
+
+	local input = vim.fn.getreg("+")
+	if input == "" then
+		return vim.notify("Clipboard Is Empty", vim.log.levels.WARN)
+	end
+
+	local tmp = vim.fn.tempname() .. ".inp"
+	vim.fn.writefile(vim.split(input, "\n"), tmp)
+
+	cmd = cmd .. " < " .. vim.fn.shellescape(tmp)
+
+	executor.run(cmd)
+end
+
+return M


### PR DESCRIPTION
Added a feature of running ":Cook test" which automatically pulls the testcase from your clipboard and serves that as input, useful for cp

Made the structure more modular and can now support subcommands, the basic function is moved to the ":Cook run" command and the run.lua file, for more features only the commands.lua needs to be updated with just an elseif statement 

simplified the init.lua

Uses the entire path in filetype.lua using vim.fn.fnamemodify(filepath, ":p") 