### PR TITLE
don't let floating terminal populate buffer list

### DIFF
--- a/lua/cook/executor.lua
+++ b/lua/cook/executor.lua
@@ -46,6 +46,7 @@ local function create_floating_terminal(cmd)
 	end)
 
 	vim.cmd("startinsert")
+	vim.bo.buflisted = false
 
 	M.state.floating.buf = buf
 	M.state.floating.win = win


### PR DESCRIPTION
When running a command, the floating terminal will populate you buffer list. Add `vim.bo.buflisted = false` will fix this.

##  Before
![image](https://github.com/user-attachments/assets/ec5a6aeb-f2e6-4109-bf0d-9752273b0d44)

## After
![image](https://github.com/user-attachments/assets/8fbf571e-ca26-45f5-8e47-ab831b04fc4b)
