### PR TITLE
feat(run): run internal vim command

### DIFF
--- a/lua/cook/commands.lua
+++ b/lua/cook/commands.lua
@@ -34,7 +34,6 @@ function M.cook(args)
 		table.sort(task_names)
 		vim.ui.select(task_names, { prompt = "Cook task: " }, function(selected_task)
 			if selected_task then
-				print("Selected task: " .. recipes_list[selected_task])
 				executor.run(recipes_list[selected_task])
 				return
 			else

--- a/lua/cook/executor.lua
+++ b/lua/cook/executor.lua
@@ -75,6 +75,12 @@ function M.run(cmd)
 		vim.notify("[Cook] Invalid or empty command", vim.log.levels.ERROR)
 		return
 	end
+
+	if string.sub(cmd, 1, 1) == "!" then
+		vim.cmd(string.sub(cmd, 2, -1))
+		return
+	end
+
 	create_floating_terminal(cmd)
 end
 


### PR DESCRIPTION
## Changes
* Removed an unnecessary `print` statement
* The task command starts with "!" will be run as Vim command like this `build = "!CMakeBuild"`. This will make `cook.nvim` can work well with other plugins like [cmake-tools.nvim](https://github.com/Civitasv/cmake-tools.nvim)

## Demo
[Screencast_20250624_192656.webm](https://github.com/user-attachments/assets/ce010c0c-d1cd-486c-b7c0-567fcdcf3434)
